### PR TITLE
Enemy movement & board turn tiles

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -14,6 +14,12 @@ Board.prototype.getClickedTile = function(clickedX, clickedY) {
   return tileArray[0];
 };
 
+Board.prototype.turnTiles = function() {
+  return this.tiles.filter(function(tile) {
+    return tile.constructor.name === 'PathTile' && tile.isTurnPoint;
+  });
+};
+
 var clickWithinTile = function(tile, clickedX, clickedY) {
   return withinXRange(tile.x, tile.x + tile.width, clickedX) &&
          withinYRange(tile.y, tile.y + tile.height, clickedY);

--- a/lib/simple-enemy.js
+++ b/lib/simple-enemy.js
@@ -4,12 +4,46 @@ var SimpleEnemy = function (coord) {
   this.speed = 1;
   this.health = 100;
   this.alive = true;
+  this.currentDirection = 'right';
 };
 
 SimpleEnemy.prototype.hit = function(damageAmount) {
   this.health = this.health - damageAmount;
-  if ( this.health <= 0 ) { this.alive = false; }  
+  if ( this.health <= 0 ) { this.alive = false; }
   return this;
+};
+
+SimpleEnemy.prototype.setDirection = function(direction) {
+  this.currentDirection = direction;
+  return this;
+};
+
+SimpleEnemy.prototype.move = function() {
+  if (this.currentDirection === 'right') {
+    this.moveRight();
+  } else if (this.currentDirection === 'left') {
+    this.moveLeft();
+  } else if (this.currentDirection === 'up') {
+    this.moveUp();
+  } else if (this.currentDirection === 'down') {
+    this.moveDown();
+  }
+};
+
+SimpleEnemy.prototype.moveRight = function() {
+  this.x = this.x + this.speed;
+};
+
+SimpleEnemy.prototype.moveLeft = function() {
+  this.x = this.x - this.speed;
+};
+
+SimpleEnemy.prototype.moveUp = function() {
+  this.y = this.y - this.speed;
+};
+
+SimpleEnemy.prototype.moveDown = function() {
+  this.y = this.y + this.speed;
 };
 
 module.exports = SimpleEnemy;

--- a/test/board-test.js
+++ b/test/board-test.js
@@ -87,3 +87,13 @@ describe('board is clicked on', function() {
     assert.equal(firstTile, clickedTile);
   });
 });
+
+describe('board has knowledge of turn tiles', function() {
+  it('returns a list of path tiles that are turn points', function() {
+    let board = new Board({15: {type: 'path', isTurn: true, direction: 'up'}, 32: {type:'path', isTurn: true, direction: 'right'}});
+
+    let turnTiles = board.turnTiles();
+
+    assert.equal(turnTiles.length, 2);
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
+require('./simple-enemy-test.js');
 require('./board-test.js');
 require('./path-tile-test.js');
 require('./tile-test.js');
 require('./build-tile-test.js');
 require('./simple-tower-test.js');
-require('./simple-enemy-test.js');
 require('./game-test.js');

--- a/test/simple-enemy-test.js
+++ b/test/simple-enemy-test.js
@@ -25,6 +25,11 @@ describe('enemy attributes', function() {
     let enemy = new SimpleEnemy({x: 1, y: 2});
     assert.typeOf(enemy.health, 'number');
   });
+
+  it('currentDirection is right by default', function() {
+    let enemy = new SimpleEnemy({x: 1, y: 2});
+    assert.equal(enemy.currentDirection, 'right');
+  });
 });
 
 describe('takes damage from a tower', function() {
@@ -38,5 +43,35 @@ describe('takes damage from a tower', function() {
     let enemy = new SimpleEnemy({x: 1, y: 2});
     enemy.hit(110);
     assert.isNotTrue(enemy.alive);
+  });
+});
+
+describe('enemy movement', function() {
+  it('moves right by value of speed if currentDirection is right', function() {
+    let enemy = new SimpleEnemy({x: 0, y: 0});
+    enemy.move();
+
+    assert.equal(enemy.x, 1);
+  });
+
+  it('moves left by value of speed if currentDirection is left', function() {
+    let enemy = new SimpleEnemy({x: 1, y: 0});
+    enemy.setDirection('left').move();
+
+    assert.equal(enemy.x, 0);
+  });
+
+  it('moves up by value of speed if currentDirection is up', function() {
+    let enemy = new SimpleEnemy({x: 0, y: 1});
+    enemy.setDirection('up').move();
+
+    assert.equal(enemy.y, 0);
+  });
+
+  it('moves up by value of speed if currentDirection is down', function() {
+    let enemy = new SimpleEnemy({x: 0, y: 0});
+    enemy.setDirection('down').move();
+
+    assert.equal(enemy.y, 1);
   });
 });


### PR DESCRIPTION
Adds the method for enemies to be able to move in a specific direction based on their current direction, and for their direction to be updated.

Also adds a method for the Board to return an array with any PathTiles that are also turn points.