### PR TITLE
Dim Tower Buttons If Not Enough Money

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -40,10 +40,7 @@ canvas {
 }
 
 .tower-button {
-  background-color: white;
   border-radius: 7px;
-  cursor: hand;
-  cursor: pointer;
   width: 90px;
   height: 90px;
   position: absolute;
@@ -106,4 +103,15 @@ canvas {
 
 #money-amount {
   font-size: 30px;
+}
+
+.inactive {
+  cursor: default;
+  background-color: grey;
+}
+
+.active {
+  background-color: white;
+  cursor: hand;
+  cursor: pointer;
 }

--- a/index.html
+++ b/index.html
@@ -15,15 +15,15 @@
       <canvas id="game-canvas" width="800" height="500"></canvas>
     </div>
     <div class="menu-container">
-      <div class="tower-button" id="simple-tower">
+      <div class="tower-button active" id="simple-tower">
         <img class="tower-image" src="/sprites/super-tower-2.png">
         <p class="tower-text">Meow Tower</p>
-        <p class="tower-text">$100</p>
+        <p class="tower-price">$100</p>
       </div>
-      <div class="tower-button" id="flash-tower">
+      <div class="tower-button active" id="flash-tower">
         <img class="tower-image" src="/sprites/whale-tower.gif">
         <p class="tower-text">Whale Tower</p>
-        <p class="tower-text">$150</p>
+        <p class="tower-price">$150</p>
       </div>
       <div class="start-button" id="start-button">
         <button type="button" id="start">Start</button>

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -1,6 +1,7 @@
 const Game = require('./game');
 const FlashTower = require('./flash-tower');
 const SimpleTower = require('./simple-tower');
+const $ = require('jquery');
 
 let game = new Game();
 let board = game.board;
@@ -9,12 +10,15 @@ let towers = game.getTowers();
 let currentTile = null;
 
 let canvas = document.getElementById('game-canvas');
+let ctx = canvas.getContext('2d');
+
 let simpleTowerButton = document.getElementById('simple-tower');
 let flashTowerButton = document.getElementById('flash-tower');
+let towerButtons = $('.tower-button');
+
 let startButton = document.getElementById('start');
 let numberOfLives = document.getElementById('number-of-lives');
 let moneyAmount = document.getElementById('money-amount');
-let ctx = canvas.getContext('2d');
 
 let images = {
   grassTile: new Image(),
@@ -73,7 +77,25 @@ function updateMoneyAmount() {
   moneyAmount.innerHTML = game.monies;
 }
 
+function updateTowerButtons() {
+  for (let i = 0; i < towerButtons.length; i ++) {
+    let towerPrice = parseInt($(towerButtons[i]).find('.tower-price').text().substr(1));
+    let currentMonies = game.monies;
+    let towerButtonState = $(towerButtons[i]).attr('class').split(' ')[1];
+
+    if (towerPrice <= currentMonies && towerButtonState === 'inactive') {
+      console.log('here');
+      $(towerButtons[i]).addClass('active');
+      $(towerButtons[i]).removeClass('inactive');
+    } else if (towerPrice > currentMonies && towerButtonState === 'active') {
+      $(towerButtons[i]).removeClass('active');
+      $(towerButtons[i]).addClass('inactive');
+    }
+  }
+}
+
 function nextTick() {
+  updateTowerButtons();
   game.removeEnemiesOffRight();
   game.rewardMonies();
   updateNumberOfLives();
@@ -89,6 +111,7 @@ let gameNotStart = true;
 //  Draws the initial board before game starts
 function startLoop() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
+  updateTowerButtons();
   updateNumberOfLives();
   updateMoneyAmount();
   drawBoard(ctx);

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -84,7 +84,6 @@ function updateTowerButtons() {
     let towerButtonState = $(towerButtons[i]).attr('class').split(' ')[1];
 
     if (towerPrice <= currentMonies && towerButtonState === 'inactive') {
-      console.log('here');
       $(towerButtons[i]).addClass('active');
       $(towerButtons[i]).removeClass('inactive');
     } else if (towerPrice > currentMonies && towerButtonState === 'active') {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-loader": "^5.3.2",
     "chai": "^3.2.0",
     "css-loader": "^0.15.5",
+    "jquery": "^2.2.2",
     "mocha": "^2.2.5",
     "mocha-loader": "^0.7.1",
     "node-libs-browser": "^0.5.2",


### PR DESCRIPTION
This branch adds to the engine class to allow the tower buttons to change from 'active' to 'inactive' and back again depending on whether or not you can afford to buy the tower.

Additionally, it adds jQuery into our project, so if we want we can refactor with jQuery later.