### PR TITLE
fixed bug where tower range was not properly displaying

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -218,7 +218,7 @@ function tileHasATower(tile) {
 function drawTowerRange(ctx) {
   if (tileIsABuildTile(currentTile) && tileHasATower(currentTile)) {
     ctx.beginPath();
-    ctx.arc(currentTile.centerX(), currentTile.centerY(), 100, 0, 2 * Math.PI, false);
+    ctx.arc(currentTile.centerX(), currentTile.centerY(), currentTile.tower.range + 25, 0, 2 * Math.PI, false);
     ctx.stroke();
   }
 }


### PR DESCRIPTION
The bug sourced from the way that the arc was being drawn.  

1. The range argument was hardcoded at 100, switched it to the current towers range.
2. Because we are sourcing from the upper left and right point for the enemy, but the center point of the tile for the tower, 25 had to be added to the radius to accurately display true range.  