### PR TITLE
Scroll fix & Mousedown fix

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -10,10 +10,16 @@ let lastTile = null;
 
 var mouseDown = false;
 $(document).mousedown(function() {
-  mouseDown = true;
+  if (eventIsOnCanvas(event)) { mouseDown = true; }
 }).mouseup(function() {
-  mouseDown = false;
+  if (eventIsOnCanvas(event)) { mouseDown = false; }
 });
+
+function eventIsOnCanvas(event) {
+  let eventPosition = getPosition(event);
+  return eventPosition.x >= 0 && eventPosition.x <= 800 &&
+         eventPosition.y >= 0 && eventPosition.y <= 500;
+}
 
 let canvas = document.getElementById('game-canvas');
 let ctx = canvas.getContext('2d');

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -160,7 +160,7 @@ function hideAllStars() {
 
 //click events, need somewhere to live.
 function getPosition(event) {
-  return { x: event.x - canvas.offsetLeft, y: event.y - canvas.offsetTop };
+  return { x: event.pageX - canvas.offsetLeft, y: event.pageY - canvas.offsetTop };
 }
 
 function selectTile(event) {


### PR DESCRIPTION
1) Fixes the issue where if you scroll down on the page, it no longer detects the correct clicked tile. We were using `event.x` instead of `event.pageX` which returns a location relative to the whole document instead of the current viewport. 

2) Also fixes the issue where if your last click was to build a tower on a BuildTile, clicking anywhere not on the canvas causes the range of the tower to be shown. I fixed this by checking if the event is within the range of the canvas before toggling the `mousedown` boolean value. Now the range is only shown if you click on the actual tower.