### PR TITLE
Reverse tower click order & show range on hover

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -56,22 +56,6 @@ p {
   width: 800px;
 }
 
-#tower-prompt {
-  color: #c20000;
-  margin: 0 auto;
-  position: relative;
-  width: 800px;
-  display: none;
-}
-
-#click-build-site-prompt {
-  color: #c20000;
-  margin: 0 auto;
-  position: relative;
-  text-align: center;
-  width: 800px;
-}
-
 h5 {
   font-size: 14px;
   letter-spacing: 2px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -169,6 +169,10 @@ canvas {
   width: 40px;
 }
 
+.dog-image {
+  margin-top: 12px;
+}
+
 .lives-left {
   background-color: #adff74;
   border-radius: 7px;

--- a/index.html
+++ b/index.html
@@ -76,14 +76,6 @@
             </div>
           </div>
         </div>
-        <div class="row">
-          <div id="tower-prompt">
-            <h5>^^ Click on a tower to add it ^^ </h5>
-          </div>
-          <div id="click-build-site-prompt">
-            <h5>Click on an empty build site square <span><img src="/sprites/build-site.jpg" alt="build site tile" width="20" /></span> then click on a tower to add it to that space</h5>
-          </div>
-        </div>
       </div>
       <div class="tower-descriptions">
         <h3>Tower Descriptions</h3>

--- a/index.html
+++ b/index.html
@@ -41,25 +41,27 @@
         </div>
         <div class="row">
           <div class="menu-container">
-            <div class="tower-button active" id="simple-tower">
-              <img class="tower-image" src="/sprites/super-tower.png">
-              <p class="tower-text">Meow Tower</p>
-              <p class="tower-price">$100</p>
-            </div>
-            <div class="tower-button active" id="heavy-damage-tower">
-              <img class="tower-image" src="/sprites/panda.gif">
-              <p class="tower-text">Panda Tower</p>
-              <p class="tower-price">$135</p>
-            </div>
-            <div class="tower-button active" id="continuous-fire-tower">
-              <img class="tower-image" src="/sprites/bunny.gif">
-              <p class="tower-text">Bunny Tower</p>
-              <p class="tower-price">$150</p>
-            </div>
-            <div class="tower-button active" id="flash-tower">
-              <img class="tower-image dog-image" src="/sprites/dog.gif">
-              <p class="tower-text">Dog Tower</p>
-              <p class="tower-price">$175</p>
+            <div id="tower-buttons">
+              <div class="tower-button active" id="simple-tower">
+                <img class="tower-image" src="/sprites/super-tower.png">
+                <p class="tower-text">Meow Tower</p>
+                <p class="tower-price">$100</p>
+              </div>
+              <div class="tower-button active" id="heavy-damage-tower">
+                <img class="tower-image" src="/sprites/panda.gif">
+                <p class="tower-text">Panda Tower</p>
+                <p class="tower-price">$135</p>
+              </div>
+              <div class="tower-button active" id="continuous-fire-tower">
+                <img class="tower-image" src="/sprites/bunny.gif">
+                <p class="tower-text">Bunny Tower</p>
+                <p class="tower-price">$150</p>
+              </div>
+              <div class="tower-button active" id="flash-tower">
+                <img class="tower-image dog-image" src="/sprites/dog.gif">
+                <p class="tower-text">Dog Tower</p>
+                <p class="tower-price">$175</p>
+              </div>
             </div>
             <div class="start-button" id="start-button">
               <a href="#" class="btn blue" id="start">Start</a>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
               <p class="tower-price">$150</p>
             </div>
             <div class="tower-button active" id="flash-tower">
-              <img class="tower-image" src="/sprites/dog.gif">
+              <img class="tower-image dog-image" src="/sprites/dog.gif">
               <p class="tower-text">Dog Tower</p>
               <p class="tower-price">$175</p>
             </div>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <h3>Instructions</h3>
         <div class="row">
           <p>
-            For each level, you start with a specific amount of paper monies and number of lives. Use your paper monies to place towers on the stone build sites.<br><br>Once you are ready, click 'Start' to call the enemies. Enemies will enter from the left and follow the brown path. You lose a life for any enemy that makes it to the right side of the board. If you lose all of your lives, you lose the game! You can replay a level if you lose, but you must win in order to move on to the next diffiulty or level.<br><br>Any time an enemy dies, you gain paper monies. Each tower is slightly different, so you may need to try several strategies to get all of the enemies.<br><br>Now go out there and destroy those enemies!
+            For each level, you start with a specific amount of paper monies and number of lives. Use your paper monies to place towers on the stone build sites. Hold your mouse down over a placed tower to see its range.<br><br>Once you are ready, click 'Start' to call the enemies. Enemies will enter from the left and follow the brown path. You lose a life for any enemy that makes it to the right side of the board. If you lose all of your lives, you lose the game! You can replay a level if you lose, but you must win in order to move on to the next diffiulty or level.<br><br>Any time an enemy dies, you gain paper monies to build more towers. Each tower is slightly different, so you may need to try several strategies to get all of the enemies.<br><br>Now go out there and destroy those enemies!
           </p>
         </div>
       </div>

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -49,8 +49,6 @@ let $nextDifficulty = $('#next-difficulty');
 let $nextLevel = $('#next-level');
 let $replay = $('#replay');
 let $replayLose = $('#replay-lose');
-let $towerPrompt = $('#tower-prompt');
-let $clickBuildSitePrompt = $('#click-build-site-prompt');
 
 $fastFowardButton.hide();
 loadImages();
@@ -248,16 +246,10 @@ function selectTile(event) {
   if (tileIsABuildTile(currentTile) && tileIsAHighlightedBuildTile(lastTile)) {
     lastTile.type = 'buildTile';
     currentTile.type = 'buildTileHighlighted';
-    $towerPrompt.show();
-    $clickBuildSitePrompt.hide();
   } else if (tileIsAHighlightedBuildTile(lastTile) && !tileIsABuildTile(currentTile)) {
     lastTile.type = 'buildTile';
-    $towerPrompt.hide();
-    $clickBuildSitePrompt.show();
   } else if (tileIsABuildTile(currentTile) && currentTile.vacant) {
     currentTile.type = 'buildTileHighlighted';
-    $towerPrompt.show();
-    $clickBuildSitePrompt.hide();
   }
 }
 
@@ -271,8 +263,6 @@ function assignOrSelectTower() {
     tower.y = currentTile.centerY();
     currentTile.addTower(tower);
     currentTile.type = 'buildTile';
-    $towerPrompt.hide();
-    $clickBuildSitePrompt.show();
     selectedTower = null;
     game.monies -= tower.price;
   }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -12,7 +12,8 @@ let game = new Game();
 let currentTile = null;
 let lastTile = null;
 let imageLoader, spriteLoader, images, sprites;
-var mouseDown = false;
+let mouseDown = false;
+let selectedTower = null;
 
 $(document).mousedown(function() {
   if (eventIsOnCanvas(event)) { mouseDown = true; }
@@ -260,29 +261,33 @@ function selectTile(event) {
   }
 }
 
-function assignTower() {
-  let centerPosition = { x: currentTile.centerX(), y: currentTile.centerY() };
-  let tower = createTowerType(this.id, centerPosition);
+function assignOrSelectTower() {
+  let tower = selectedTower || createTowerType(this.id);
 
-  if (tileIsAHighlightedBuildTile(currentTile) && canAffordTower(tower.price)) {
+  if (!tileIsAHighlightedBuildTile(currentTile)) {
+    selectedTower = createTowerType(this.id);
+  } else if (tileIsAHighlightedBuildTile(currentTile) && canAffordTower(tower.price)) {
+    tower.x = currentTile.centerX();
+    tower.y = currentTile.centerY();
     currentTile.addTower(tower);
     currentTile.type = 'buildTile';
     $towerPrompt.hide();
     $clickBuildSitePrompt.show();
+    selectedTower = null;
     game.monies -= tower.price;
   }
 }
 
-function createTowerType(id, centerPosition) {
+function createTowerType(id) {
   switch (id) {
     case 'simple-tower':
-      return new SimpleTower(centerPosition);
+      return new SimpleTower({x: 0, y:0 });
     case 'flash-tower':
-      return new FlashTower(centerPosition);
+      return new FlashTower({x: 0, y:0 });
     case 'heavy-damage-tower':
-      return new HeavyDamageTower(centerPosition);
+      return new HeavyDamageTower({x: 0, y:0 });
     case 'continuous-fire-tower':
-      return new ContinuousFireTower(centerPosition);
+      return new ContinuousFireTower({x: 0, y:0 });
   }
 }
 
@@ -349,10 +354,11 @@ function resetParameters() {
 }
 
 canvas.addEventListener("mousedown", selectTile);
-simpleTowerButton.addEventListener("click", assignTower);
-flashTowerButton.addEventListener("click", assignTower);
-heavyDamageTowerButton.addEventListener("click", assignTower);
-continuousFireTowerButton.addEventListener("click", assignTower);
+canvas.addEventListener("mousedown", assignOrSelectTower);
+simpleTowerButton.addEventListener("click", assignOrSelectTower);
+flashTowerButton.addEventListener("click", assignOrSelectTower);
+heavyDamageTowerButton.addEventListener("click", assignOrSelectTower);
+continuousFireTowerButton.addEventListener("click", assignOrSelectTower);
 startButton.addEventListener("click", function() {
   gameNotStarted = false;
   replaceStartButtonWithFastFoward();

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -258,7 +258,7 @@ function assignOrSelectTower() {
 
   if (!tileIsAHighlightedBuildTile(currentTile)) {
     selectedTower = createTowerType(this.id);
-  } else if (tileIsAHighlightedBuildTile(currentTile) && canAffordTower(tower.price)) {
+  } else if (tileIsAHighlightedBuildTile(currentTile) && tower && canAffordTower(tower.price)) {
     tower.x = currentTile.centerX();
     tower.y = currentTile.centerY();
     currentTile.addTower(tower);

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -84,14 +84,14 @@ function drawAnimations(ctx) {
 }
 
 function routeAnimation (a, ctx) {
-  if (a.nature === 'fire'){
-    if(a.tower.type === 'flashTower'){
+  if (a.nature === 'fire') {
+    if(a.tower.type === 'flashTower') {
       ctx.drawImage(a.currentFrame, a.tower.x - (a.tower.range / 2), a.tower.y - (a.tower.range / 2));
     } else {
       rotateAndDrawImage(ctx, a);
     }
-  } else if (a.nature === 'hit' && a.enemy !== null){
-    if(a.tower.type === 'heavyDamageTower') {
+  } else if (a.nature === 'hit' && a.enemy !== null) {
+    if (a.tower.type === 'heavyDamageTower') {
       ctx.drawImage(a.currentFrame, a.enemy.x - 5, a.enemy.y - 30);
     } else {
       ctx.drawImage(a.currentFrame, a.enemy.x, a.enemy.y - 11);

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -14,11 +14,21 @@ let lastTile = null;
 let imageLoader, spriteLoader, images, sprites;
 let mouseDown = false;
 let selectedTower = null;
+let mouseEnter = false;
+let hoverTower = null;
 
 $(document).mousedown(function() {
   if (eventIsOnCanvas(event)) { mouseDown = true; }
 }).mouseup(function() {
   if (eventIsOnCanvas(event)) { mouseDown = false; }
+});
+
+$('#simple-tower, #heavy-damage-tower, #continuous-fire-tower, #flash-tower').mouseenter(function() {
+  mouseEnter = true;
+  hoverTower = createTowerType(this.id);
+}).mouseleave(function() {
+  mouseEnter = false;
+  hoverTower = null;
 });
 
 function eventIsOnCanvas(event) {
@@ -179,6 +189,7 @@ function startLoop() {
   drawBoard(ctx);
   drawTowers(ctx);
   if (mouseDown) { drawTowerRange(ctx); }
+  if (mouseEnter) { simulateTowerRange(ctx); }
   if (gameNotStarted) { requestAnimationFrame(startLoop); }
 }
 
@@ -190,6 +201,7 @@ function gameLoop() {
   drawTowers(ctx);
   drawAnimations(ctx);
   if (mouseDown) { drawTowerRange(ctx); }
+  if (mouseEnter) { simulateTowerRange(ctx); }
   nextTick();
 
   if (game.checkStatus() === 'ongoing') {
@@ -302,6 +314,15 @@ function drawTowerRange(ctx) {
     ctx.beginPath();
     ctx.arc(currentTile.centerX(), currentTile.centerY(),
             currentTile.tower.range, 0, 2 * Math.PI, false);
+    ctx.stroke();
+  }
+}
+
+function simulateTowerRange(ctx) {
+  if (tileIsAHighlightedBuildTile(currentTile)) {
+    ctx.beginPath();
+    ctx.arc(currentTile.centerX(), currentTile.centerY(),
+            hoverTower.range, 0, 2 * Math.PI, false);
     ctx.stroke();
   }
 }


### PR DESCRIPTION
This branch accomplishes two things:

1) The user can now select a tower, then place it onto a square. Before we had it so you always had to select the square first, but trails with people at Turing taught us that people seem to want to go the other direction (at least initially).

2) If the user selects a build tile and then hovers over any of the tower buttons, the range of the tower will be shown. This helps for placing towers because you will know if it will reach the path before placing it.